### PR TITLE
Enforce Single Outgoing Connections

### DIFF
--- a/addons/state_machine/state_machine_delta.gd
+++ b/addons/state_machine/state_machine_delta.gd
@@ -2,6 +2,9 @@
 class_name StateMachineDelta
 extends Resource
 
+signal transition_added(transition: Transition)
+signal transition_removed(transition: Transition)
+
 @export var transitions: Array[Transition] = []
 @export var graph_coords: Dictionary = {}
 
@@ -17,19 +20,55 @@ func find_transition(from: String, signal_name: StringName, to: String) -> int:
 			idx += 1
 	return idx if found else -1
 
+## Like find_transition, but only checks the from and signal name of the transition
+func find_outgoing_transition(from: String, signal_name: StringName) -> int:
+	var target := Transition.new(from, signal_name)
+	var idx := 0
+	var found := false
+	while idx < transitions.size() and not found:
+		var actual_transition := transitions[idx]
+		var candidate := Transition.new(actual_transition.from, actual_transition.signal_name)
+		if candidate.equals(target):
+			found = true
+		else:
+			idx += 1
+	return idx if found else -1
+
 func has_transition(from: String, signal_name: StringName, to: String) -> bool:
 	return find_transition(from, signal_name, to) > -1
 
+## Returns true if there exists any transition coming from the given state with the given signal
+func has_outgoing_transition(from: String, signal_name: StringName) -> bool:
+	return find_outgoing_transition(from, signal_name) > -1
+
 func add_transition(from: String, signal_name: StringName, to: String) -> void:
-	if not has_transition(from, signal_name, to):
-		transitions.append(Transition.new(from, signal_name, to))
-		emit_changed()
+	remove_outgoing_transition(from, signal_name)
+	if not has_transition(from, signal_name, to): # Just in case. We really don't want duplicates
+		var t: Transition = Transition.new(from, signal_name, to)
+		transitions.append(t)
+		emit_transition_added(t)
+
+func remove_outgoing_transition(from: String, signal_name: StringName) -> void:
+	var idx := find_outgoing_transition(from, signal_name)
+	remove_transition_at_idx(idx)
 
 func remove_transition(from: String, signal_name: StringName, to: String) -> void:
 	var idx := find_transition(from, signal_name, to)
+	remove_transition_at_idx(idx)
+
+func remove_transition_at_idx(idx: int) -> void:
 	if idx > -1:
+		var t := transitions[idx]
 		transitions.remove_at(idx)
-		emit_changed()
+		emit_transition_removed(t)
+
+func emit_transition_added(t: Transition) -> void:
+	emit_changed()
+	transition_added.emit(t)
+
+func emit_transition_removed(t: Transition) -> void:
+	emit_changed()
+	transition_removed.emit(t)
 
 func inspect() -> void:
 	print("Inspecting %s" %[self])


### PR DESCRIPTION
Automatically removes transitions from a state and particular signal if another transition from that signal is being added, ensuring that each signal on a state has at most one transition.

Also, the GraphEdit now only draws transitions based on signals from the StateMachineDelta rather than immediately on connection request. This makes it so the Delta is treated more as a source of truth.
